### PR TITLE
feat: Use passed collection settings in route

### DIFF
--- a/src/routes/(pb)/$collection/route.tsx
+++ b/src/routes/(pb)/$collection/route.tsx
@@ -31,7 +31,7 @@ export const Route = createFileRoute('/(pb)/$collection')({
 
     protectPage(location)
 
-    const context: PbRouteLoaderContext = {collection_settings, collection: params.collection}
+    const context: PbRouteLoaderContext = {collection_settings, collection: collection_settings.collection || params.collection}
 
     return context
   },


### PR DESCRIPTION
The collection setting is now primarily fetched from the passed collection settings object, with a fallback to the route params. This provides more flexibility in how collection context is provided to the route.